### PR TITLE
feat: handle direct routing to class files

### DIFF
--- a/LightWeightFramework/Exception/OutputBufferException.php
+++ b/LightWeightFramework/Exception/OutputBufferException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LightWeightFramework\Exception;
+
+class OutputBufferException extends \Exception
+{
+    public function __construct(
+        string $message,
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/LightWeightFramework/Routing/RouteCollection.php
+++ b/LightWeightFramework/Routing/RouteCollection.php
@@ -79,7 +79,6 @@ class RouteCollection
         foreach (scandir($controllerFolder) as $fileName) {
             // Handle only PHP files, that are not associated to a class
             if (str_ends_with($controllerFolder . $fileName, '.php')
-                && !class_exists("\\App\\Controller\\" . str_replace(".php", "", $fileName), false)
             ) {
                 $routes["/$fileName"] = $fileName;
             }

--- a/src/Controller/HandleRedirect.php
+++ b/src/Controller/HandleRedirect.php
@@ -5,8 +5,15 @@ namespace App\Controller;
 use LightWeightFramework\Http\Response\RedirectResponse;
 use LightWeightFramework\Http\Response\Response;
 
+return (new HandleRedirect())->renderText();
+
 class HandleRedirect
 {
+    public function renderText(): string
+    {
+        return "HTML raw content goes here";
+    }
+
     public function redirect(): Response
     {
         return new RedirectResponse("/Procedural");

--- a/src/Controller/NotProcedural.php
+++ b/src/Controller/NotProcedural.php
@@ -4,8 +4,15 @@ namespace App\Controller;
 
 use LightWeightFramework\Http\Response\Response;
 
+return (new NotProcedural())->renderResponse();
+
 class NotProcedural
 {
+    public function renderResponse(): Response
+    {
+        return new Response("HTML content");
+    }
+
     public function route(): Response
     {
         return new Response( __CLASS__ . " : Route test.");


### PR DESCRIPTION
- Every file in src/Controller is registered for direct rounting (meaning that: src/Controller/FileA.php is available at http://localhost/FileA.php)
- If it's a procedural script, it's executed
- If it's a class and/or there is nothing to render, an exception will be thrown