### PR TITLE
Better handling of redirects by 

### DIFF
--- a/LightWeightFramework/LightWeightFramework.php
+++ b/LightWeightFramework/LightWeightFramework.php
@@ -5,6 +5,7 @@ namespace LightWeightFramework;
 use LightWeightFramework\Container\Container;
 use LightWeightFramework\Exception\OutputBufferException;
 use LightWeightFramework\Http\Request\Request;
+use LightWeightFramework\Http\Response\RedirectResponse;
 use LightWeightFramework\Http\Response\Response;
 use LightWeightFramework\Routing\Router;
 
@@ -33,17 +34,18 @@ class LightWeightFramework
             if (file_exists($responsePath)) {
                 ob_start();
                 $output = require $responsePath;
+                $content = ob_get_clean();
 
-                if (!$content = ob_get_clean()) {
-                    if ($output instanceof Response) {
-                        return $output;
-                    }
-                    if (\is_string($output)) {
-                        return new Response($output);
-                    }
-                    throw new OutputBufferException("Unrecoverable output buffer error");
+                if (\is_string($output)) {
+                    $output = new Response($output);
                 }
-                return new Response($content);
+                if ($output instanceof Response) {
+                    return $output;
+                }
+                if (\is_string($content) && $content !== "") {
+                    return new Response($content);
+                }
+                throw new OutputBufferException("Unrecoverable output buffer error");
             }
         }
 

--- a/src/Controller/ProceduralRedirect.php
+++ b/src/Controller/ProceduralRedirect.php
@@ -1,0 +1,6 @@
+<?php
+
+echo "Some text";
+
+header("Location: /DirectAccess.php");
+exit;

--- a/tests/Request/RedirectionTest.php
+++ b/tests/Request/RedirectionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\Request;
+
+use LightWeightFramework\Exception\OutputBufferException;
+use LightWeightFramework\Http\Request\Request;
+use LightWeightFramework\LightWeightFramework;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+class RedirectionTest extends TestCase
+{
+    public function testRedirectResponse(): void
+    {
+        $f = new LightWeightFramework();
+
+        $request = Request::createFromGlobals()->setRequestUri("/ClassRedirect");
+        $response = $f->handle($request);
+
+        self::assertSame(302, $response->getReturnCode());
+        $location = $response->getHeaders()->location;
+        self::assertStringContainsString("<meta http-equiv=\"refresh\" content=\"0;url=$location\" />",
+            $response->getContent());
+
+        $request->setRequestUri($location);
+        $response = $f->handle($request);
+
+        self::assertSame(200, $response->getReturnCode());
+    }
+
+    public function testRedirectToNoRouteFound(): void
+    {
+        $f = new LightWeightFramework();
+
+        $request = Request::createFromGlobals()->setRequestUri("/ErrorOnRedirect");
+        $response = $f->handle($request);
+
+        self::assertSame(302, $response->getReturnCode());
+        $location = $response->getHeaders()->location;
+        self::assertStringContainsString("<meta http-equiv=\"refresh\" content=\"0;url=$location\" />",
+            $response->getContent());
+
+        $request->setRequestUri($location);
+        $response = $f->handle($request);
+
+        self::assertSame(404, $response->getReturnCode());
+    }
+
+    /**
+     * Simulated request cannot be tested because of the exit() after the header()
+     * @return void
+     */
+    public function testRedirectWithProceduralHeader(): void
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, "http://localhost/ProceduralRedirect.php");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $output = curl_exec($ch);
+
+        self::assertSame(302, curl_getinfo($ch, CURLINFO_HTTP_CODE));
+        self::assertSame('Some text', $output);
+
+        curl_close($ch);
+    }
+
+    /**
+     * Simulated request cannot be tested because of the exit() after the header()
+     * @return void
+     */
+    public function testFollowRedirectWithProceduralHeader(): void
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, "http://localhost/ProceduralRedirect.php");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        $output = curl_exec($ch);
+
+        self::assertSame(200, curl_getinfo($ch, CURLINFO_HTTP_CODE));
+        self::assertSame('In direct access. Running procedural script(s).', $output);
+
+        curl_close($ch);
+    }
+}

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -172,40 +172,6 @@ class RequestTest extends TestCase
         self::assertSame("No route found", $response->getContent());
     }
 
-    public function testRedirectResponse(): void
-    {
-        $f = new LightWeightFramework();
-
-        $request = Request::createFromGlobals()->setRequestUri("/ClassRedirect");
-        $response = $f->handle($request);
-
-        self::assertSame(302, $response->getReturnCode());
-        $location = $response->getHeaders()->location;
-        self::assertStringContainsString("<meta http-equiv=\"refresh\" content=\"0;url=$location\" />", $response->getContent());
-
-        $request->setRequestUri($location);
-        $response = $f->handle($request);
-
-        self::assertSame(200, $response->getReturnCode());
-    }
-
-    public function testRedirectToNoRouteFound(): void
-    {
-        $f = new LightWeightFramework();
-
-        $request = Request::createFromGlobals()->setRequestUri("/ErrorOnRedirect");
-        $response = $f->handle($request);
-
-        self::assertSame(302, $response->getReturnCode());
-        $location = $response->getHeaders()->location;
-        self::assertStringContainsString("<meta http-equiv=\"refresh\" content=\"0;url=$location\" />", $response->getContent());
-
-        $request->setRequestUri($location);
-        $response = $f->handle($request);
-
-        self::assertSame(404, $response->getReturnCode());
-    }
-
     public function testProceduralRoutingTowardsClassFileWithNoOutput(): void
     {
         $request = Request::createFromGlobals()->setRequestUri("/EmptyClass.php");


### PR DESCRIPTION
- Better rendering of responses when using `header('Location : xxx')`
- Testing only using cURL. Testing with request / response breaks phpunit because of the `exit()` function after the header