### PR TITLE
Update tests to match Routing define in production

### DIFF
--- a/src/Service/ServiceA.php
+++ b/src/Service/ServiceA.php
@@ -2,6 +2,8 @@
 
 namespace App\Service;
 
+return (new ServiceA())->do();
+
 class ServiceA
 {
     public string $name = "Service A";

--- a/src/configure.php
+++ b/src/configure.php
@@ -1,0 +1,5 @@
+<?php
+
+use LightWeightFramework\Routing\RouteCollection;
+
+RouteCollection::registerPathForDirectRouting('Service');

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -234,4 +234,14 @@ class RequestTest extends TestCase
 
         self::assertSame("HTML content", $response->getContent());
     }
+
+    public function testDirectAccessToService(): void
+    {
+        $f = new LightWeightFramework();
+
+        $request = Request::createFromGlobals()->setRequestUri("/Service/ServiceA.php");
+        $response = $f->handle($request);
+
+        self::assertSame("Do", $response->getContent());
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 // Auto-register classes
+use LightWeightFramework\Routing\RouteCollection;
+
 spl_autoload_register(function ($class) {
     $class = str_replace(['\\', 'App/'], ['/', 'src/'], $class);
     $classFile = __DIR__ . '/../' . $class . '.php';
@@ -13,3 +15,5 @@ spl_autoload_register(function ($class) {
 set_error_handler(function ($errno, $errstr, $errfile, $errline) {
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 });
+
+RouteCollection::registerPathForDirectRouting('Service');


### PR DESCRIPTION
`index.php` defines :
```
RouteCollection::registerPathForDirectRouting('Service');
```

This configuration is not reproduced in tests.

This PR adds the configuration to `bootstrap.php` so tests know this to be registered.