### PR TITLE
Centralisation of framework configuration

### DIFF
--- a/LightWeightFramework/LightWeightFramework.php
+++ b/LightWeightFramework/LightWeightFramework.php
@@ -5,12 +5,23 @@ namespace LightWeightFramework;
 use LightWeightFramework\Container\Container;
 use LightWeightFramework\Exception\OutputBufferException;
 use LightWeightFramework\Http\Request\Request;
-use LightWeightFramework\Http\Response\RedirectResponse;
 use LightWeightFramework\Http\Response\Response;
 use LightWeightFramework\Routing\Router;
 
 class LightWeightFramework
 {
+    public function __construct()
+    {
+        $this->configure();
+    }
+
+    public function configure(string $path = __DIR__ . '/../src/configure.php'): void
+    {
+        if (file_exists($path)) {
+            include $path;
+        }
+    }
+
     public function handle(?Request $request = null): Response
     {
         Container::build();

--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,6 @@
 
 use LightWeightFramework\Http\Response\Response;
 use LightWeightFramework\LightWeightFramework;
-use LightWeightFramework\Routing\RouteCollection;
 
 // Auto-register classes
 spl_autoload_register(static function ($class) {
@@ -18,10 +17,9 @@ set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 });
 
-RouteCollection::registerPathForDirectRouting('Service');
-
 try {
-    $response = (new LightWeightFramework())->handle();
+    $f = new LightWeightFramework();
+    $response = $f->handle();
     $response->send();
 } catch (\Exception $e) {
     $response = new Response($e->getMessage(), 404);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 // Auto-register classes
+use LightWeightFramework\LightWeightFramework;
 use LightWeightFramework\Routing\RouteCollection;
 
 spl_autoload_register(function ($class) {
@@ -15,5 +16,3 @@ spl_autoload_register(function ($class) {
 set_error_handler(function ($errno, $errstr, $errfile, $errline) {
     throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 });
-
-RouteCollection::registerPathForDirectRouting('Service');


### PR DESCRIPTION
Use of `configure.php` to centralise configuration
The file will be used both in production and tests